### PR TITLE
Removed Skype

### DIFF
--- a/ansible/playbooks/linux/install-gui-apps.yml
+++ b/ansible/playbooks/linux/install-gui-apps.yml
@@ -28,13 +28,6 @@
     state: present
   become: true
 
-# Install Skype (Snap)
-- name: Install Skype via Snap
-  snap:
-    name: skype
-    state: present
-  become: true
-
 # --- Install TightVNC Server ---
 - name: Install TightVNC Server
   apt:


### PR DESCRIPTION
This pull request includes a change to the `ansible/playbooks/linux/install-gui-apps.yml` file, specifically removing the installation of Skype via Snap. This change simplifies the playbook by removing an unnecessary application installation.

Changes to `ansible/playbooks/linux/install-gui-apps.yml`:

* Removed the task to install Skype via Snap, which included specifying the Snap package and setting its state to present. This change reduces the number of applications installed by the playbook.