### PR TITLE
feat: added macOs automated setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Automated Workspace Setup
+## Automated Workspace Setup Ubuntu 24.04 LTS
 
 Automated workspace setup tool for Ubuntu 24.04 LTS (macOS and Windows 11 Support coming soon) that configures development environments, virtualization tools, and GUI applications using Ansible. Please make sure you have atleast 8GB of RAM and 30GB of free disk space before running the script.
 
@@ -64,3 +64,61 @@ Notes
 2. Verify installations using version check commands
 3. Configure additional application settings as needed
 4. The playbook handles most configurations automatically, but some applications may need additional setup through their GUIs.
+
+## Automated Workspace Setup for macOS 15.4
+
+Automated workspace setup tool for macOS 15.4 that configures development environments and applications using Ansible. Please make sure you have at least 16GB of RAM and 60GB of free disk space before running the script.
+
+### Features
+1. Docker + Docker CLI
+2. VirtualBox + Multipass
+3. Development Tools (Git, Vim, Screen, Python3, Rust)
+4. GUI Applications (Chrome, VS Code, Spotify, VLC)
+5. Productivity Tools (Adobe Reader, ProtonVPN)
+6. Package Manager (Homebrew)
+7. Command Line Tools (Xcode)
+8. Automated cleanup
+
+## Prerequisites
+1. Install [Homebrew](https://brew.sh/). You can run the following command in your terminal:
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+Press `Enter` to continue and follow the prompts. Please make sure to run the following commands (or similar commands that the brew installer outputs) after the installation is complete to add Homebrew to your PATH:
+```bash
+echo >> /Users/gajesh/.zprofile
+echo 'eval "$(/usr/local/bin/brew shellenv)"' >> /Users/gajesh/.zprofile
+eval "$(/usr/local/bin/brew shellenv)"
+```
+
+2. Install [Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html). You can run the following command in your terminal:
+```bash
+brew install ansible
+```
+Check it's installed correctly:
+```bash
+ansible --version
+```
+
+3. Clone this repository:
+```bash
+git clone https://github.com/gajeshbhat/auto-workspace.git
+cd auto-workspace/ansible
+```
+
+4. Update the `macos.yml` file with your Git global user name, and email:
+```yaml
+vars:
+  git_global_user_name: "Your Name"
+  git_global_user_email: "your.email@example.com"
+```
+
+5. Run the playbook:
+```bash
+ansible-playbook macos.yml --ask-become-pass # Enter your sudo password when prompted for BECOME Password and Enter password as requested
+```
+
+6. Check mode (dry run) to see what would change
+```bash
+ansible-playbook macos.yml --check --ask-become-pass
+```

--- a/ansible/macos.yml
+++ b/ansible/macos.yml
@@ -1,0 +1,34 @@
+---
+- name: MacOS Workstation Setup (15.4)
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  become: false
+  vars:
+    username: "{{ lookup('env', 'USER') }}"
+    git_global_user_name: "Your Name"
+    git_global_user_email: "your.email@example.com"
+    brew_casks:
+      - google-chrome
+      - spotify
+      - visual-studio-code
+      - vlc
+      - transmission
+      - protonvpn
+      - virtualbox
+      - multipass
+      - docker
+    brew_formulae:
+      - screen
+      - git
+      - htop
+      - vim
+      - python3
+      - rust
+      
+  tasks:
+    - import_tasks: playbooks/macos/initial-setup.yml
+    - import_tasks: playbooks/macos/install-applications.yml
+    - import_tasks: playbooks/macos/install-dev-tools.yml
+    - import_tasks: playbooks/macos/configure-environments.yml
+    - import_tasks: playbooks/macos/cleanup.yml

--- a/ansible/playbooks/macos/cleanup.yml
+++ b/ansible/playbooks/macos/cleanup.yml
@@ -1,0 +1,30 @@
+---
+- name: Cleanup Homebrew
+  command: brew cleanup
+  ignore_errors: yes
+
+- name: Clear Homebrew cache
+  file:
+    path: "~/Library/Caches/Homebrew"
+    state: absent
+  ignore_errors: yes
+
+- name: Remove Homebrew downloads
+  file:
+    path: "~/Library/Caches/Homebrew/downloads"
+    state: absent
+  ignore_errors: yes
+
+- name: Clear system logs
+  shell: |
+    sudo rm -rf /private/var/log/asl/*.asl
+    sudo rm -rf /Library/Logs/DiagnosticReports/*
+    sudo rm -rf /Library/Logs/Adobe/*
+    sudo rm -rf ~/Library/Containers/com.apple.mail/Data/Library/Logs/Mail/*
+    sudo rm -rf ~/Library/Logs/CoreSimulator/*
+  become: true
+  ignore_errors: yes
+
+- name: Empty trash
+  shell: rm -rf ~/.Trash/*
+  ignore_errors: yes

--- a/ansible/playbooks/macos/configure-environments.yml
+++ b/ansible/playbooks/macos/configure-environments.yml
@@ -1,0 +1,12 @@
+---
+- name: Check if Multipass is installed
+  command: which multipass
+  register: multipass_check
+  ignore_errors: yes
+  changed_when: false
+
+- name: Configure Multipass
+  shell: |
+    multipass set local.driver=virtualbox
+  ignore_errors: yes
+  when: multipass_check.rc == 0

--- a/ansible/playbooks/macos/initial-setup.yml
+++ b/ansible/playbooks/macos/initial-setup.yml
@@ -1,0 +1,33 @@
+---
+- name: Check if Xcode Command Line Tools are installed
+  command: xcode-select -p
+  register: xcode_select
+  ignore_errors: yes
+  changed_when: false
+
+- name: Install Xcode Command Line Tools
+  command: xcode-select --install
+  register: xcode_install
+  failed_when: xcode_install.rc != 0 and xcode_install.stderr.find('already installed') == -1
+  changed_when: xcode_install.rc == 0
+  ignore_errors: yes
+  when: xcode_select.rc != 0
+
+- name: Check if full Xcode is installed
+  stat:
+    path: "/Applications/Xcode.app"
+  register: xcode_app
+
+- name: Accept Xcode License
+  shell: xcodebuild -license accept
+  become: true
+  ignore_errors: yes
+  when: xcode_app.stat.exists
+
+- name: Accept Command Line Tools License
+  shell: |
+    sudo xcodebuild -license accept
+    sudo xcode-select --reset
+  become: true
+  ignore_errors: yes
+  when: not xcode_app.stat.exists

--- a/ansible/playbooks/macos/install-applications.yml
+++ b/ansible/playbooks/macos/install-applications.yml
@@ -1,0 +1,15 @@
+---
+- name: Install Homebrew Cask Applications
+  community.general.homebrew_cask:
+    name: "{{ item }}"
+    state: present
+    accept_external_apps: yes  # Accept if app is already installed
+  loop: "{{ brew_casks }}"
+  become: false
+  ignore_errors: yes
+
+- name: Check if Docker is Already Installed
+  command: docker --version
+  register: docker_check
+  ignore_errors: yes
+  changed_when: false

--- a/ansible/playbooks/macos/install-dev-tools.yml
+++ b/ansible/playbooks/macos/install-dev-tools.yml
@@ -1,0 +1,15 @@
+---
+- name: Install Development Tools via Homebrew
+  community.general.homebrew:
+    name: "{{ item }}"
+    state: present
+    install_options: "{{ 'formula' if item != 'docker' else '' }}"
+  loop: "{{ brew_formulae }}"
+  become: false
+  ignore_errors: yes
+
+- name: Configure Git global settings
+  shell: |
+    git config --global user.name "{{ git_global_user_name }}"
+    git config --global user.email "{{ git_global_user_email }}"
+  become: false


### PR DESCRIPTION
This pull request includes significant updates to the automated workspace setup, adding support for macOS 15.4, and making various improvements to the Ansible playbooks. The most important changes include the addition of a new section in the `README.md` for macOS setup, the creation of a new Ansible playbook for macOS, and the inclusion of tasks to configure and clean up the macOS environment.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R67-R124): Added a new section detailing the automated workspace setup for macOS 15.4, including prerequisites, features, and setup steps.

### Ansible Playbook Additions:
* [`ansible/macos.yml`](diffhunk://#diff-74eaffaddb7e6ee392f81e5060f6bea50b791cdb80f2292b2257c744fb4e0e38R1-R34): Created a new playbook for macOS workstation setup, defining tasks for initial setup, application installation, development tools installation, environment configuration, and cleanup.

### Task Definitions:
* [`ansible/playbooks/macos/initial-setup.yml`](diffhunk://#diff-980befab9fab53efe221e8b92f2c5ed2451e1b9f7d825e2cd755085c1390416cR1-R33): Added tasks to check and install Xcode Command Line Tools, accept licenses, and ensure Xcode is properly configured.
* [`ansible/playbooks/macos/install-applications.yml`](diffhunk://#diff-7b673cfd6873990f8d52619fd0b980a02e89f1ceb242ca557f1033dc3d48c6b4R1-R15): Defined tasks to install Homebrew cask applications and check for Docker installation.
* [`ansible/playbooks/macos/install-dev-tools.yml`](diffhunk://#diff-b04413635672e5c2b934c289d6a992800045f235c59c5c5f99ba3f5c70662e45R1-R15): Added tasks to install development tools via Homebrew and configure Git global settings.

### Cleanup Tasks:
* [`ansible/playbooks/macos/cleanup.yml`](diffhunk://#diff-3ebd5c66f937cfb410d8ca1446fb557b1645f7e04c653d21b318b79b8424afa2R1-R30): Included tasks to clean up Homebrew, clear system logs, and empty the trash to maintain a tidy environment.