### PR TITLE
feat(macOS/UTM): add UTM test workflow; tag/skip virtualization tasks

### DIFF
--- a/ansible/playbooks/macos/configure-environments.yml
+++ b/ansible/playbooks/macos/configure-environments.yml
@@ -1,11 +1,13 @@
 ---
 - name: Check if Multipass is installed
+  tags: [virtualization, multipass]
   command: which multipass
   register: multipass_check
   ignore_errors: yes
   changed_when: false
 
-- name: Configure Multipass
+- name: Configure Multipass (skippable inside VM)
+  tags: [virtualization, multipass]
   shell: |
     multipass set local.driver=virtualbox
   ignore_errors: yes

--- a/ansible/playbooks/macos/install-applications.yml
+++ b/ansible/playbooks/macos/install-applications.yml
@@ -1,10 +1,23 @@
 ---
-- name: Install Homebrew Cask Applications
+- name: Install non-virtualization Homebrew Cask apps
+  tags: [apps]
   community.general.homebrew_cask:
     name: "{{ item }}"
     state: present
-    accept_external_apps: yes  # Accept if app is already installed
-  loop: "{{ brew_casks }}"
+    accept_external_apps: yes
+  # everything except virtualization-related casks
+  loop: "{{ brew_casks | difference(['virtualbox','multipass','docker']) }}"
+  become: false
+  ignore_errors: yes
+
+- name: Install virtualization Homebrew Cask apps (skippable inside VM)
+  tags: [virtualization, virtualbox, multipass, docker]
+  community.general.homebrew_cask:
+    name: "{{ item }}"
+    state: present
+    accept_external_apps: yes
+  # only the virtualization casks that are present in brew_casks
+  loop: "{{ ['virtualbox','multipass','docker'] | intersect(brew_casks) }}"
   become: false
   ignore_errors: yes
 

--- a/ansible/playbooks/macos/install-dev-tools.yml
+++ b/ansible/playbooks/macos/install-dev-tools.yml
@@ -1,10 +1,18 @@
 ---
-- name: Install Development Tools via Homebrew
+- name: Install Dev Tools (non-Docker)
+  tags: [devtools]
   community.general.homebrew:
     name: "{{ item }}"
     state: present
-    install_options: "{{ 'formula' if item != 'docker' else '' }}"
-  loop: "{{ brew_formulae }}"
+  loop: "{{ brew_formulae | difference(['docker']) }}"
+  become: false
+  ignore_errors: yes
+
+- name: Install Docker (skippable inside VM)
+  tags: [virtualization, docker]
+  community.general.homebrew:
+    name: docker
+    state: present
   become: false
   ignore_errors: yes
 

--- a/scripts/macos-guest/run-ansible.sh
+++ b/scripts/macos-guest/run-ansible.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run Ansible playbook from the auto-mounted UTM share on a macOS guest.
+# Usage (inside guest Terminal):
+#   sudo bash "/Volumes/My Shared Files/<Your Share Name>/scripts/macos-guest/run-ansible.sh"
+
+log() { echo "[+] $*"; }
+err() { echo "[!] $*" >&2; }
+
+# Discover the auto-mounted UTM share path that contains this script.
+# This allows you to invoke the script regardless of the share folder name.
+SCRIPT_PATH="$(cd "$(dirname "$0")" && pwd)"
+SHARE_ROOT="$(cd "$SCRIPT_PATH/../../" && pwd)"  # This should resolve to the repo root inside the share
+
+# Sanity check: does ansible/macos.yml exist?
+if [[ ! -f "$SHARE_ROOT/ansible/macos.yml" ]]; then
+  err "Could not find ansible/macos.yml under $SHARE_ROOT. Are you running from the auto-mounted share?"
+  exit 1
+fi
+
+install_xcode_clt() {
+  if xcode-select -p >/dev/null 2>&1; then return; fi
+  log "Installing Xcode Command Line Tools (may prompt)..."
+  touch /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
+  PROD=$(softwareupdate -l 2>/dev/null | awk -F'*' '/Command Line Tools/ {print $2}' | sed 's/^ *//' | tail -n1 || true)
+  if [[ -n "$PROD" ]]; then
+    softwareupdate -i "$PROD" --agree-to-license || true
+  fi
+  rm -f /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress || true
+}
+
+install_homebrew() {
+  if command -v brew >/dev/null 2>&1; then return; fi
+  log "Installing Homebrew..."
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  if [[ -d /opt/homebrew/bin ]]; then
+    eval "$('/opt/homebrew/bin/brew' shellenv)"
+    echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> /etc/zprofile
+  elif [[ -d /usr/local/bin ]]; then
+    eval "$('/usr/local/bin/brew' shellenv)"
+    echo 'eval "$(/usr/local/bin/brew shellenv)"' >> /etc/zprofile
+  fi
+}
+
+install_ansible() {
+  if command -v ansible >/dev/null 2>&1; then return; fi
+  log "Installing Ansible via Homebrew..."
+  brew install ansible
+}
+
+run_playbook() {
+  log "Running Ansible macOS playbook (skip virtualization tags in VM)"
+  ANSIBLE_STDOUT_CALLBACK=yaml ansible-playbook "$SHARE_ROOT/ansible/macos.yml" --skip-tags virtualization,docker,virtualbox,multipass -K -vv || true
+}
+
+main() {
+  install_xcode_clt || true
+  install_homebrew || true
+  install_ansible || true
+  run_playbook
+  log "Done."
+}
+
+main "$@"
+

--- a/scripts/utm/quickstart-utm-macos.sh
+++ b/scripts/utm/quickstart-utm-macos.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Quickstart (Phase 0) for creating a macOS VM in UTM and preparing to run Ansible.
+# This script does NOT create the VM for you (UTM GUI does), but prints the exact steps and
+# opens UTM. Afterwards, you will run the guest-side script to install Ansible and execute your playbook.
+#
+# Usage:
+#   scripts/utm/quickstart-utm-macos.sh [--open]
+#
+# Tips:
+# - Use your existing IPSW file when the UTM wizard asks for it
+# - Name the VM (e.g., macos-ci)
+# - Networking: NAT
+# - Add a Shared Directory pointing to your repo root (Read-only is fine)
+# - In new UTM versions, the share auto-mounts at: /Volumes/My Shared Files/<Your Share Name>
+
+OPEN_UTM="false"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --open) OPEN_UTM="true"; shift ;;
+    *) echo "Unknown arg: $1" >&2; exit 2;;
+  esac
+done
+
+log() { echo "[+] $*"; }
+
+cat <<'EOF'
+
+==========================
+UTM macOS VM: Phase 0 Steps
+==========================
+1) Launch UTM and create a new VM:
+   - Click "+" > Virtualize > macOS
+   - Select your IPSW file when prompted
+   - Name the VM (e.g., macos-ci)
+   - Assign CPU/RAM (e.g., 4 CPU, 8 GB) and a disk (e.g., 64 GB)
+   - Networking: NAT
+   - Sharing: Add a Shared Directory pointing to your repo root (Read-only optional)
+     NOTE: New UTM auto-mounts shares under: /Volumes/My Shared Files/<Your Share Name>
+
+2) Start the VM and complete Setup Assistant (one time only).
+
+3) In the guest (macOS) Terminal, run the Ansible runner from the auto-mounted share path:
+   a) Discover the auto-mounted path:
+      - ls "/Volumes/My Shared Files"
+      - cd "/Volumes/My Shared Files/<Your Share Name>"
+   b) Run the guest-side script (installs Homebrew + Ansible, runs your playbook):
+      - sudo bash "/Volumes/My Shared Files/<Your Share Name>/scripts/macos-guest/run-ansible.sh"
+
+4) Rinse & repeat: After you change your repo on the host, just re-run step 3b inside the guest.
+
+Troubleshooting:
+- If you don't see your share in Finder > Computer > My Shared Files, ensure the VM Settings > Sharing has your folder added.
+- If auto-mount isn't present, fall back to manual mount (may not be needed on latest UTM):
+  sudo mkdir -p /Volumes/HostShare
+  sudo mount -t virtiofs share /Volumes/HostShare
+  Then run:
+  sudo bash /Volumes/HostShare/scripts/macos-guest/run-ansible.sh
+
+EOF
+
+if [[ "$OPEN_UTM" == "true" ]]; then
+  log "Opening UTM..."
+  open -a UTM || true
+fi
+
+log "Quickstart printed. Open UTM (or re-run with --open) and follow the steps above."
+


### PR DESCRIPTION
- Add scripts/utm/quickstart-utm-macos.sh to guide one-time UTM VM setup
- Add scripts/macos-guest/run-ansible.sh to install CLT+Homebrew+Ansible and run ansible/macos.yml from UTM auto-mounted share
- Tag virtualization tasks and split installs:
- ansible/playbooks/macos/install-applications.yml: split casks; tag [virtualization, virtualbox, multipass, docker]
- ansible/playbooks/macos/configure-environments.yml: tag Multipass tasks [virtualization, multipass]
- ansible/playbooks/macos/install-dev-tools.yml: split Docker; tag [virtualization, docker]
- Default guest run to skip virtualization tasks: --skip-tags virtualization,docker,virtualbox,multipass

Usage:
- Host: scripts/utm/quickstart-utm-macos.sh --open
- Guest: sudo bash "/Volumes/My Shared Files//scripts/macos-guest/run-ansible.sh"