### PR TITLE
Added Steam Snap to automated GUI Apps install playbook

### DIFF
--- a/ansible/playbooks/linux/install-gui-apps.yml
+++ b/ansible/playbooks/linux/install-gui-apps.yml
@@ -28,6 +28,13 @@
     state: present
   become: true
 
+# Install Steam (Snap)
+- name: Install Steam game platform
+  snap:
+    name: steam
+    state: present
+  become: true
+
 # --- Install TightVNC Server ---
 - name: Install TightVNC Server
   apt:


### PR DESCRIPTION
This pull request adds the installation of the Steam game platform to the Ansible playbook for installing GUI applications on Linux. The change uses Snap to ensure Steam is present on the system.

New application installation:

* Added a task to install the Steam game platform using Snap in `ansible/playbooks/linux/install-gui-apps.yml`.