### PR TITLE
feat: Add nmap and net-tools to CLI tools install on linux

### DIFF
--- a/ansible/playbooks/linux/install-dev-tools.yml
+++ b/ansible/playbooks/linux/install-dev-tools.yml
@@ -13,6 +13,8 @@
       - tmux
       - ifstat
       - vnstat
+      - nmap
+      - net-tools
     state: present
 
 - name: Check if rustup is already installed


### PR DESCRIPTION
Add nmap and net-tools to CLI tools install for Ubuntu 24.04.3 LTS.